### PR TITLE
Fix force try

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -214,8 +214,8 @@ public protocol FailableIterator: IteratorProtocol {
 
 extension FailableIterator {
     public func next() -> Element? {
-        // swiftlint:disable:next force_try
-        try! failableNext()
+        // Do not force try 
+        try? failableNext()
     }
 }
 

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1009,10 +1009,9 @@ extension Connection {
         let statement = try prepare(expression.template, expression.bindings)
 
         let columnNames = try columnNamesForQuery(query)
+        let rows = try statement.failableNext().map { Row(columnNames, $0) }
 
-        return AnySequence {
-            AnyIterator { statement.next().map { Row(columnNames, $0) } }
-        }
+        return AnySequence { AnyIterator { rows } }
     }
 
     public func prepareRowIterator(_ query: QueryType) throws -> RowIterator {


### PR DESCRIPTION
- Fix: Do not force try the FailableIterator.next()
- Fix: Use failableNext() in prepare so that if the try fails it will rethrow

There is a fork of the SQLite.swift repo in the BiAffect org, but it has not been updated and maintained, nor pushed back to the head.

